### PR TITLE
🐛  Small fix for bug in compensation function.

### DIFF
--- a/pytometry/preprocessing/_process_data.py
+++ b/pytometry/preprocessing/_process_data.py
@@ -178,7 +178,8 @@ def compensate(
 
     if np.array_equal(X, adata.X):
         print(
-            "Compensation failed - matrices before and after are equivalent. Please check your compensation matrix."
+            "Compensation failed - matrices before and after are equivalent. Please"
+            " check your compensation matrix."
         )
     del X
 


### PR DESCRIPTION
This PR fixes an issue that arises when no indices between the compensation matrix columns and the adatas index (or channel column) are intersecting. Previously this was not caught because  `idx_in is None` doesn't check if `idx_in` is empty and therefore not caught. I also added a check if X has changed after compensation and am logging a warning if it hasn't.