### PR TITLE
Copy original data in `compensate`

### DIFF
--- a/pytometry/preprocessing/_process_data.py
+++ b/pytometry/preprocessing/_process_data.py
@@ -142,7 +142,7 @@ def compensate(
 
     # save original data as layer
     if "original" not in adata.layers:
-        adata.layers["original"] = adata.X
+        adata.layers["original"] = adata.X.copy()
 
     # Ignore channels 'FSC-H', 'FSC-A', 'SSC-H', 'SSC-A',
     # 'FSC-Width', 'Time'


### PR DESCRIPTION
Currently, the layer `original` will just store a reference to `X` which will be modified as well.