### PR TITLE
Update dependencies with Python versions and numpy 2, fix inplace argument description, make consensus clustering reproducible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
       - name: Install build dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,11 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
           cache: "pip"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,6 @@ jobs:
           - os: ubuntu-latest
             python: "3.11"
           - os: ubuntu-latest
-            python: "3.12"
-          - os: ubuntu-latest
             python: "3.13"
           - os: ubuntu-latest
             python: "3.13"
@@ -41,9 +39,9 @@ jobs:
       PYTHON: ${{ matrix.python }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -66,4 +64,4 @@ jobs:
         run: |
           coverage report
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: "3.10"
+            python: "3.11"
           - os: ubuntu-latest
             python: "3.12"
           - os: ubuntu-latest
-            python: "3.12"
+            python: "3.13"
+          - os: ubuntu-latest
+            python: "3.13"
             pip-flags: "--pre"
             name: PRE-RELEASE DEPENDENCIES
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ __pycache__/
 # Data files from tutorials
 /docs/notebooks/*.fcs
 /docs/notebooks/*.h5ad
+
+# uv lock file
+/uv.lock
+
+# Test FCS files
+/*.fcs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.8
+    rev: v0.14.2
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
-        args: [--select, "I,RUF022", --fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--select, "I,RUF022", --fix, --exit-non-zero-on-fix]
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
 sphinx:
   configuration: docs/conf.py
   # disable this for more lenient docs builds
-  fail_on_warning: true
+  fail_on_warning: false
 python:
   install:
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
 sphinx:
   configuration: docs/conf.py
   # disable this for more lenient docs builds
-  fail_on_warning: false
+  fail_on_warning: true
 python:
   install:
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 sphinx:
   configuration: docs/conf.py
   # disable this for more lenient docs builds

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please refer to the [documentation][link-docs]. In particular, the
 
 ## Installation
 
-You need to have Python 3.10 or newer installed on your system. If you don't have
+You need to have Python 3.11 or newer installed on your system. If you don't have
 Python installed, we recommend installing [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
 
 There are several alternative options to install pytometry:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pytometry is currently a pre-print on [bioRxiv](https://www.biorxiv.org/content/
 
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/scverse/pytometry/issues
-[changelog]: ./docs/contributing.md
+[contributing]: https://pytometry.readthedocs.io/en/stable/contributing.html
 [changelog]: https://github.com/scverse/pytometry/releases
 [link-docs]: https://pytometry.readthedocs.io
 [link-api]: https://pytometry.readthedocs.io/latest/api.html

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ pip install pytometry
 pip install git+https://github.com/scverse/pytometry.git@main
 ```
 
+3. Install locally for development:
+
+Please refer to the [Contributing Guide][contributing].
+
 ## Release notes
 
 See [GitHub releases][changelog].
@@ -54,6 +58,7 @@ Pytometry is currently a pre-print on [bioRxiv](https://www.biorxiv.org/content/
 
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/scverse/pytometry/issues
+[changelog]: ./docs/contributing.md
 [changelog]: https://github.com/scverse/pytometry/releases
 [link-docs]: https://pytometry.readthedocs.io
 [link-api]: https://pytometry.readthedocs.io/latest/api.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,4 +129,5 @@ nitpick_ignore = [
     # If building the documentation fails because of a missing link that is outside your control,
     # you can add an exception to this list.
     #     ("py:class", "igraph.Graph"),
+    ("py:data", "typing.Union"),
 ]

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -183,6 +183,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Fix column names with forward slashes before saving (not allowed by AnnData)\n",
+    "adata.uns[\"meta\"][\"spill\"].columns = adata.uns[\"meta\"][\"spill\"].columns.str.replace(\"/\", \"_\")\n",
     "adata.write(\"example.h5ad\")"
    ]
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pre-commit",
+    "ruff==0.14.2"
 ]
 doc = [
     "docutils>=0.8,!=0.18.*,!=0.19.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
     "C4",  # flake8-comprehensions
     "BLE",  # flake8-blind-except
     "UP",  # pyupgrade
+    "RUF022", # Reorder __all__ with isort-style rules
     "RUF100",  # Report unused noqa directives
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pytometry"
 dynamic = ["version"]
 description = "Flow & mass cytometry analytics in scverse"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [
     {name = "Maren Büttner"},
@@ -28,11 +28,10 @@ dependencies = [
     "scipy",
     "seaborn",
     "matplotlib",
-    "readfcs >=1.1.0",
+    "readfcs>=1.1.0",
     "flowutils",
-    "consensusclustering",
-    "minisom"
-
+    "consensusclustering>=0.2.4",
+    "minisom",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ urls.Documentation = "https://pytometry.readthedocs.io/"
 urls.Source = "https://github.com/scverse/pytometry"
 urls.Home-page = "https://github.com/scverse/pytometry"
 dependencies = [
-    "numpy>=1.20.0",
+    "numpy>=2.0.0",
     "numba>=0.57",
     "pandas",
     "anndata",

--- a/src/pytometry/__init__.py
+++ b/src/pytometry/__init__.py
@@ -2,6 +2,6 @@ from importlib.metadata import version
 
 from . import io, pl, pp, tl
 
-__all__ = ["pl", "pp", "tl", "io"]
+__all__ = ["io", "pl", "pp", "tl"]
 
 __version__ = version("pytometry")

--- a/src/pytometry/_types.py
+++ b/src/pytometry/_types.py
@@ -1,0 +1,6 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+RNGLike = np.random.Generator | np.random.BitGenerator

--- a/src/pytometry/pp/_process_data.py
+++ b/src/pytometry/pp/_process_data.py
@@ -53,6 +53,7 @@ def find_indexes(
     data_type
         Type of cytometry data
     inplace
+        Update adata and return None if True. Otherwise, return a copy of adata with the changes.
 
     Returns
     -------
@@ -116,7 +117,7 @@ def compensate(
         matrices. Usually, custom compensation matrices are the inverse of the spillover matrix. If you want to use
         a compensation matrix, not the spillover matrix, set `matrix_type` to `compensation`.
     inplace
-        Return a copy instead of writing to adata.
+        Update adata and return None if True. Otherwise, return a copy of adata with the changes.
 
     Returns
     -------
@@ -209,7 +210,7 @@ def split_signal(
     data_type
         Type of cytometry data
     inplace
-        Return a copy instead of writing to adata.
+        Update adata and return None if True. Otherwise, return a copy of adata with the changes.
 
     Returns
     -------

--- a/src/pytometry/tl/clustering/_flowsom.py
+++ b/src/pytometry/tl/clustering/_flowsom.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TypedDict
 
 import numpy as np
@@ -9,6 +10,9 @@ from consensusclustering import ConsensusClustering
 from minisom import MiniSom
 from sklearn.cluster import AgglomerativeClustering
 from tqdm.auto import tqdm
+
+SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+RNGLike = np.random.Generator | np.random.BitGenerator
 
 logger = logging.getLogger("pytometry.flowsom")
 
@@ -81,6 +85,7 @@ def meta_clustering(
     resample_frac: float = 0.5,
     verbose: bool = False,
     agglomerative_clustering_kwargs: dict | None = None,
+    rng: RNGLike | SeedLike | None = None,
 ) -> tuple[np.ndarray, ConsensusClustering]:
     """Meta-clustering of SOM nodes using consensus clustering.
 
@@ -106,6 +111,8 @@ def meta_clustering(
     agglomerative_clustering_kwargs
         keyword arguments for `sklearn.cluster.AgglomerativeClustering`. If None, defaults to
         {"metric": "euclidean", "linkage": "average"}.
+    rng
+        random number generator or seed for reproducibility
 
     Returns
     -------
@@ -123,6 +130,7 @@ def meta_clustering(
         max_clusters=max_clusters,
         n_resamples=n_resamples,
         resample_frac=resample_frac,
+        rng=rng,
     )
     weights = som.get_weights()
     flatten_weights = weights.reshape(som._activation_map.shape[0] * som._activation_map.shape[1], n_features)
@@ -237,6 +245,7 @@ def flowsom_clustering(
         resample_frac=resample_frac,
         verbose=verbose,
         agglomerative_clustering_kwargs=agglomerative_clustering_kwargs,
+        rng=seed,
     )
     logger.info("Assigning cluster labels to cells")
     x = np.array(adata.X)

--- a/src/pytometry/tl/clustering/_flowsom.py
+++ b/src/pytometry/tl/clustering/_flowsom.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from typing import TypedDict
 
 import numpy as np
@@ -11,8 +10,7 @@ from minisom import MiniSom
 from sklearn.cluster import AgglomerativeClustering
 from tqdm.auto import tqdm
 
-SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
-RNGLike = np.random.Generator | np.random.BitGenerator
+from pytometry._types import RNGLike, SeedLike
 
 logger = logging.getLogger("pytometry.flowsom")
 


### PR DESCRIPTION
- Updates to Numpy 2, closes #80 
- Aligns Python versions used for tests and elsewhere with Scientific Python SPEC0
- Requires `consensusclustering` version with reproducibility bug fix, adds `rng` argument for reproducibility on the `pytometry` side, too (I would also happy to move the use of `seed` elsewhere in the library to SPEC 7 if desired, since this has not been discussed, this PR maintains backwards compatibility for now)
- Fixes #87