### PR TITLE
add read_fcs params from readfcs==2.1.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "minisom",
   "numba>=0.57",
   "numpy>=2",
-  "readfcs>=1.1",
+  "readfcs>=2.1",
   "scanpy",
 ]
 optional-dependencies.dev = [

--- a/src/pytometry/io/_readfcs.py
+++ b/src/pytometry/io/_readfcs.py
@@ -27,7 +27,7 @@ def read_fcs(
         Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
         Default is False
     use_header_offsets
-        Use the HEADER section for the data offset locations. Default is False. 
+        Use the HEADER section for the data offset locations. Default is False.
         Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns
@@ -76,7 +76,7 @@ def read_and_merge(
         Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
         Default is False
     use_header_offsets
-        Use the HEADER section for the data offset locations. Default is False. 
+        Use the HEADER section for the data offset locations. Default is False.
         Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns

--- a/src/pytometry/io/_readfcs.py
+++ b/src/pytometry/io/_readfcs.py
@@ -6,7 +6,13 @@ from anndata import AnnData
 from tqdm.auto import tqdm
 
 
-def read_fcs(path: str, reindex: bool = True) -> AnnData:
+def read_fcs(
+    path: str,
+    reindex: bool = True,
+    ignore_offset_error: bool = False,
+    ignore_offset_discrepancy: bool = False,
+    use_header_offsets: bool = False,
+) -> AnnData:
     """Read FCS file and convert into AnnData format.
 
     Parameters
@@ -15,12 +21,24 @@ def read_fcs(path: str, reindex: bool = True) -> AnnData:
         location of fcs file to parse
     reindex
         use the marker info to reindex variable names
+    ignore_offset_error: Ignore data offset error.
+        Default is False
+    ignore_offset_discrepancy: Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
+        Default is False
+    use_header_offsets: Use the HEADER section for the data offset locations.
+        Default is False. Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns
     -------
     An AnnData object of the fcs file
     """
-    return readfcs.read(path, reindex=reindex)
+    return readfcs.read(
+        path,
+        reindex=reindex,
+        ignore_offset_error=ignore_offset_error,
+        ignore_offset_discrepancy=ignore_offset_discrepancy,
+        use_header_offsets=use_header_offsets,
+    )
 
 
 def read_and_merge(
@@ -29,6 +47,10 @@ def read_and_merge(
     sample_id_from_filename: bool = False,
     sample_id_index: int = 0,
     sample_id_sep: str = "_",
+    reindex: bool = True,
+    ignore_offset_error: bool = False,
+    ignore_offset_discrepancy: bool = False,
+    use_header_offsets: bool = False,
 ) -> AnnData:
     """Read and merge multiple FCS files into a single AnnData object.
 
@@ -44,6 +66,14 @@ def read_and_merge(
         which index of the filename to use as the sample id
     sample_id_sep
         separator to use when splitting the filename
+    reindex
+        use the marker info to reindex variable names
+    ignore_offset_error: Ignore data offset error.
+        Default is False
+    ignore_offset_discrepancy: Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
+        Default is False
+    use_header_offsets: Use the HEADER section for the data offset locations.
+        Default is False. Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns
     -------
@@ -63,7 +93,13 @@ def read_and_merge(
 
     adata_stack = []
     for file, file_id in tqdm(zip(files, sample_ids, strict=False), total=len(files), desc="Loading FCS files"):
-        adata = read_fcs(file)
+        adata = read_fcs(
+            file,
+            reindex=reindex,
+            ignore_offset_error=ignore_offset_error,
+            ignore_offset_discrepancy=ignore_offset_discrepancy,
+            use_header_offsets=use_header_offsets,
+        )
         if file_id is not None:
             adata.obs["sample"] = file_id
         adata_stack.append(adata)

--- a/src/pytometry/io/_readfcs.py
+++ b/src/pytometry/io/_readfcs.py
@@ -21,12 +21,14 @@ def read_fcs(
         location of fcs file to parse
     reindex
         use the marker info to reindex variable names
-    ignore_offset_error: Ignore data offset error.
+    ignore_offset_error
+        Ignore data offset error. Default is False
+    ignore_offset_discrepancy
+        Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
         Default is False
-    ignore_offset_discrepancy: Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
-        Default is False
-    use_header_offsets: Use the HEADER section for the data offset locations.
-        Default is False. Setting this option to True also suppresses an error in cases of an offset discrepancy.
+    use_header_offsets
+        Use the HEADER section for the data offset locations. Default is False. 
+        Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns
     -------
@@ -68,12 +70,14 @@ def read_and_merge(
         separator to use when splitting the filename
     reindex
         use the marker info to reindex variable names
-    ignore_offset_error: Ignore data offset error.
+    ignore_offset_error
+        Ignore data offset error. Default is False
+    ignore_offset_discrepancy
+        Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
         Default is False
-    ignore_offset_discrepancy: Ignore discrepancy between the HEADER and TEXT values for the DATA byte offset location.
-        Default is False
-    use_header_offsets: Use the HEADER section for the data offset locations.
-        Default is False. Setting this option to True also suppresses an error in cases of an offset discrepancy.
+    use_header_offsets
+        Use the HEADER section for the data offset locations. Default is False. 
+        Setting this option to True also suppresses an error in cases of an offset discrepancy.
 
     Returns
     -------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,6 +23,14 @@ def test_read_fcs2():
     assert isinstance(adata, anndata._core.anndata.AnnData)
 
 
+# test read function with ignore_offset_error=True
+# TODO: find available FCS file with offset error
+def test_read_fcs_with_offset_error():
+    path_data = readfcs.datasets.Oetjen18_t1()
+    adata = read_fcs(path_data, reindex=True, ignore_offset_error=True)
+    assert isinstance(adata, anndata._core.anndata.AnnData)
+
+
 # test compensate
 def test_compensate():
     path_data = readfcs.datasets.Oetjen18_t1()


### PR DESCRIPTION
In `readfcs` 2.1.0, additional parameters were added to `readfcs.read`, like `ignore_offset_error`.
Citing from [FlowKit's documentation](https://flowkit.readthedocs.io/en/latest/sample.html):

> Some FCS files incorrectly report the location of the last data byte as the last byte exclusive of the data section rather than the last byte inclusive of the data section. Technically, these are invalid FCS files but these are not corrupted data files. To attempt to read in these files, set the ignore_offset_error option to True.

This pull request also enables pytometry users to pass those parameters down to readfcs. 